### PR TITLE
feat: redirect users to SSO's registration page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,13 +17,14 @@ Add this project to requirements.
 Also add `python-jose==3.0.0` since it is not being picked up from the project's requirements.
 
 Your private.txt should looke like this at the end:
+
 ..  code-block:: yaml
 
   -e ./edx-oauth2-auth0-backend/
   python-jose==3.0.0
 
 
-3. configure your Open edX lms application
+2. configure your Open edX lms application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: yaml

--- a/README.rst
+++ b/README.rst
@@ -34,5 +34,5 @@ Your private.txt should looke like this at the end:
   THIRD_PARTY_AUTH_BACKENDS:
   - "auth0_oauth2.auth0.Auth0OAuth2"
   ENABLE_REQUIRE_THIRD_PARTY_AUTH: true
-
-
+  SOCIAL_AUTH_AUTH0_PLUGIN_FIELDS_STORED_IN_SESSION:
+  - "auth_entry"

--- a/auth0_oauth2/auth0.py
+++ b/auth0_oauth2/auth0.py
@@ -76,3 +76,15 @@ class Auth0OAuth2(BaseOAuth2):
             return {
                 "user_id": payload["sub"]
             }
+
+    def auth_extra_arguments(self):
+        extra_arguments = super().auth_extra_arguments()
+
+        # Open edX passes auth_entry query parameter which signifies if it was a login or a registration page
+        auth_entry = self.strategy.session_get("auth_entry", default=None)
+        if auth_entry == "register":
+            # Auth0 accepts screen_hint=signup on /authorize endpoint to redirect to sign up page
+            # https://auth0.com/docs/authenticate/login/auth0-universal-login/new-experience#signup
+            extra_arguments["screen_hint"] = "signup"
+
+        return extra_arguments


### PR DESCRIPTION
### Description

When an unauthenticated user visits LMS's registration form, if they click on an SSO option, or if they are automatically redirected to the SSO by the LMS (if configured), we want them to be redirected to the Auth0's registration (aka sign up) page. However currently, they will always be redirected to the Auth0's login page.

This PR modifies the plugin, so that when users are coming from the LMS's registration page, they will be redirected to the Auth0's registration page. 